### PR TITLE
리펙토링: AuditingDields 클래스를 추상 클래스로 변경

### DIFF
--- a/project-board/src/main/java/com/spring/projectboard/domain/AuditingFields.java
+++ b/project-board/src/main/java/com/spring/projectboard/domain/AuditingFields.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @ToString
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public class AuditingFields {
+public abstract class AuditingFields {
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate


### PR DESCRIPTION
엔티티에서 상속을 해서 사용해야 하는 목적에 더 잘맞게 'abstract' 키워드를 추가하였음. 별도 이슈 없이 작업함.