### PR TITLE
.gitignore 에 JPA Buddy 플러그인의 설정 파일을 무시하도록 룰 추가

### DIFF
--- a/project-board/.gitignore
+++ b/project-board/.gitignore
@@ -8,6 +8,9 @@
 ### Querydsl
 /src/main/generated
 
+### JPA Buddy
+.jpb/
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml


### PR DESCRIPTION
Intellij Plugin 중 JPA 작업을 편리하게 해주는 JPA Buddy 라는 플러그인을 사용하여 자동 생성되는 설정 파일이 프로젝트에 포함되지 않도록 '.gitignore' 를 통해 파일 무시 규칙을 추가하였음.