### PR TITLE
리팩토링: DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/project-board/src/main/java/com/spring/projectboard/dto/response/ArticleCommentResponse.java
+++ b/project-board/src/main/java/com/spring/projectboard/dto/response/ArticleCommentResponse.java
@@ -2,7 +2,6 @@ package com.spring.projectboard.dto.response;
 
 import com.spring.projectboard.dto.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleCommentResponse(
@@ -11,7 +10,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/project-board/src/main/java/com/spring/projectboard/dto/response/ArticleResponse.java
+++ b/project-board/src/main/java/com/spring/projectboard/dto/response/ArticleResponse.java
@@ -2,7 +2,6 @@ package com.spring.projectboard.dto.response;
 
 import com.spring.projectboard.dto.ArticleDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleResponse(
@@ -13,7 +12,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/project-board/src/main/java/com/spring/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/project-board/src/main/java/com/spring/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -2,7 +2,6 @@ package com.spring.projectboard.dto.response;
 
 import com.spring.projectboard.dto.ArticleWithCommentsDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -17,7 +16,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentResponses
-) implements Serializable {
+) {
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);
     }


### PR DESCRIPTION
JPA Buddy 를 이용한 DTO 들에 자동으로 'implements Serializable' 이 들어감. 해당 프로젝트는 직렬화로 Jackson 을 사용하므로 필요하지 않고, 의도하여 추가한 코드가 아니므로 삭제하였음.